### PR TITLE
Remove compile warning about Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.15)
 project(bio_ik)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
   set(CMAKE_BUILD_TYPE Release)
 endif()
 


### PR DESCRIPTION
This removes the unnecessary compile warning:

```
--- stderr: bio_ik                                                                                                                                             
bio_ik: You did not request a specific build type: Choosing 'Release' for maximum performance
---
```